### PR TITLE
Increase module flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ In addition, you will need to make sure the following settings are correct:
 This ensures that the xbee can communicate with Zigbee ZDO/ZCL devices, which is required by the Zigbee Home Automation Profile.
 The ATAP=1 also ensures that the xbee is placed into API mode.
 
+For more information on configuring XBee series 2 radios as ZigBee coordinators see [Digi's knowledge base article](http://knowledge.digi.com/articles/Knowledge_Base_Article/Zigbee-Home-Automation).
+
 ## Usage
 ![flow](flow.png)
 ![mqtt-flow](mqtt-flow.png)
@@ -48,6 +50,8 @@ Control of the bulbs is done fairly simply. Send a message to the node, with one
     * _Sets the color temperature (if supported)_
 * [0-255],[0,255]
     * _Sets the hue and saturation (if supported)_
+
+You can also override the specified bulb type and topic (if any) by sending msg.bulbtype and/or msg.topic to the control. This can help eliminate the need for multiple ZigBee bulb controls.
 
 If you dim a bulb, then turn it off, the next time you turn it on, it will be at the same brightness level.
 

--- a/node-red-contrib-zblight.html
+++ b/node-red-contrib-zblight.html
@@ -47,8 +47,8 @@ limitations under the License.
       </select>
     </div>
     <div class="form-row">
-      <label for="node-input-mac"><i class="icon-globe"></i> MAC</label>
-      <input type="text" id="node-input-mac" placeholder="Mac Address" />
+      <label for="node-input-topic"><i class="fa fa-tasks"></i> Topic</label>
+      <input type="text" id="node-input-topic" placeholder="Mac Address" />
     </div>
 </script>
 

--- a/node-red-contrib-zblight.html
+++ b/node-red-contrib-zblight.html
@@ -21,7 +21,7 @@ limitations under the License.
     defaults: {
       name: {value:""},
       bulbtype: {value:""},
-      mac: {value:""}
+      topic: {value:""}
     },
     inputs: 1,
     outputs: 1,

--- a/node-red-contrib-zblight.js
+++ b/node-red-contrib-zblight.js
@@ -15,9 +15,37 @@
 module.exports = function(RED) {
   function zbLightNode(config) {
     RED.nodes.createNode(this, config);
-    this.mac = config.mac;
-    this.bulbtype = config.bulbtype;
-
+    
+    // Make sure the topic isn't undefined.
+    if (typeof msg.topic != "undefined") {
+      // If the topic is empty...
+      if (msg.topic === "") {
+        // Use topic from configuration.
+        this.topic = config.topic;
+      } else {
+        // Use topic from message.
+        this.topic = msg.topic;
+      }
+    } else {
+      // Use topic from configuration.
+      this.topic = config.topic;
+    }
+    
+    // Make sure the bulb type isn't undefined.
+    if (typeof msg.bulbtype != "undefined") {
+      // If the bulb type is empty...
+      if (msg.bulbtype === "") {
+        // Use bulb type from configuration.
+        this.bulbtype = config.bulbtype;
+      } else {
+        // Get the bulb type from the message.
+        this.bulbtype = msg.bulbtype;
+      }
+    } else {
+      // Use bulb type from configuration.
+      this.bulbtype = config.bulbtype;
+    }
+    
     var endpoint = 0x00;
     if (this.bulbtype.toLowerCase() == "ge") {
       endpoint = 0x01;
@@ -68,7 +96,7 @@ module.exports = function(RED) {
       var frame_obj = {
         type: 0x11,
         id: 0x01,
-        destination64: this.mac,
+        destination64: this.topic,
         destination16: "fffe",
         sourceEndpoint: 0xE8,
         destinationEndpoint: endpoint,
@@ -77,7 +105,7 @@ module.exports = function(RED) {
         broadcastRadius: 0x00,
         options: 0x00,
         data: lightPayload
-      }
+      };
       msg.payload = xbee.buildFrame(frame_obj);
       node.send(msg);
     });

--- a/node-red-contrib-zblight.js
+++ b/node-red-contrib-zblight.js
@@ -18,17 +18,6 @@ module.exports = function(RED) {
     this.bulbtype = config.bulbtype;
     this.topic = config.topic;
     
-    var endpoint = 0x00;
-    if (this.bulbtype.toLowerCase() == "ge") {
-      endpoint = 0x01;
-    } else if (this.bulbtype.toLowerCase() == "cree") {
-      endpoint = 0x0A;
-    } else if (this.bulbtype.toLowerCase() == "hue") {
-      endpoint = 0x0B;
-    } else if (this.bulbtype.toLowerCase() == "lightify") {
-      endpoint = 0x03;
-    }
-
     var xbeeapi = require('xbee-api');
     var xbee = new xbeeapi.XBeeAPI();
     var node = this;
@@ -54,6 +43,17 @@ module.exports = function(RED) {
           // Get the bulb type from the message.
           this.bulbtype = msg.bulbtype;
         }
+      }
+      
+      var endpoint = 0x00;
+      if (this.bulbtype.toLowerCase() == "ge") {
+        endpoint = 0x01;
+      } else if (this.bulbtype.toLowerCase() == "cree") {
+        endpoint = 0x0A;
+      } else if (this.bulbtype.toLowerCase() == "hue") {
+        endpoint = 0x0B;
+      } else if (this.bulbtype.toLowerCase() == "lightify") {
+        endpoint = 0x03;
       }
       
       if (msg.payload.toString().toLowerCase() == "on") {

--- a/node-red-contrib-zblight.js
+++ b/node-red-contrib-zblight.js
@@ -15,36 +15,8 @@
 module.exports = function(RED) {
   function zbLightNode(config) {
     RED.nodes.createNode(this, config);
-    
-    // Make sure the topic isn't undefined.
-    if (typeof msg.topic != "undefined") {
-      // If the topic is empty...
-      if (msg.topic === "") {
-        // Use topic from configuration.
-        this.topic = config.topic;
-      } else {
-        // Use topic from message.
-        this.topic = msg.topic;
-      }
-    } else {
-      // Use topic from configuration.
-      this.topic = config.topic;
-    }
-    
-    // Make sure the bulb type isn't undefined.
-    if (typeof msg.bulbtype != "undefined") {
-      // If the bulb type is empty...
-      if (msg.bulbtype === "") {
-        // Use bulb type from configuration.
-        this.bulbtype = config.bulbtype;
-      } else {
-        // Get the bulb type from the message.
-        this.bulbtype = msg.bulbtype;
-      }
-    } else {
-      // Use bulb type from configuration.
-      this.bulbtype = config.bulbtype;
-    }
+    this.bulbtype = config.bulbtype;
+    this.topic = config.topic;
     
     var endpoint = 0x00;
     if (this.bulbtype.toLowerCase() == "ge") {
@@ -65,7 +37,25 @@ module.exports = function(RED) {
 
       var outputCluster = 0x0000;
       var lightPayload = 0;
-
+      
+      // Make sure the topic isn't undefined.
+      if (typeof msg.topic != "undefined") {
+        // If the topic is empty...
+        if (msg.topic !== "") {
+          // Use topic from message.
+          this.topic = msg.topic;
+        }
+      }
+      
+      // Make sure the bulb type isn't undefined.
+      if (typeof msg.bulbtype != "undefined") {
+        // If the bulb type is empty...
+        if (msg.bulbtype !== "") {
+          // Get the bulb type from the message.
+          this.bulbtype = msg.bulbtype;
+        }
+      }
+      
       if (msg.payload.toString().toLowerCase() == "on") {
         lightPayload = [ 0x01, 0x00, 0x01, 0x00, 0x10];
         outputCluster = 0x0006;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-zblight",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "dependencies": {
     "xbee-api": "latest"
   },


### PR DESCRIPTION
The changes I'm proposing will allow this module to be used in a streamlined fashion where we don't need one object per bulb, which will allow us to override the configured MAC value with a MAC specified in msg.topic, and the same with the bulb type if msg.bulbtype is specified. The rest are standardization, stylistic, and documentation changes.
- Use msg.topic to override the specified MAC in the control if it is present in the msg object.
- Use msg.bubltype to override the specified bulb type in the control if it is present in the msg object.
- Update the control to use "Topic" and the topic icon from the core Node-RED controls in the configuration page.

The screen caps haven't been updated.